### PR TITLE
Adding sys.executable to find path to python

### DIFF
--- a/src/notebook_kernel.py
+++ b/src/notebook_kernel.py
@@ -20,6 +20,7 @@ import uuid
 import subprocess
 import json
 import os
+import sys
 import shutil
 from pathlib import Path
 
@@ -175,7 +176,7 @@ class NotebookKernel:
         Returns: whether `ipykernel` is installed in environment.
         """
         assert self.venv_path
-        executable = str(Path(self.venv_path).joinpath("bin/python"))
+        executable = sys.executable
         cmd = [
             executable,
             "-c",

--- a/src/notebook_kernel.py
+++ b/src/notebook_kernel.py
@@ -36,6 +36,7 @@ class NotebookKernel:
     def __init__(self) -> None:
         self.ksm = kernelspec.KernelSpecManager()
         self.venv_path = os.getenv("VIRTUAL_ENV") or os.getenv("CONDA_PREFIX")
+        self.executable = sys.executable
         self.in_venv = self.venv_path is not None
         self.kernel_client: BlockingKernelClient | None = None
         self.kernel_manager: KernelManager | None = None
@@ -175,8 +176,9 @@ class NotebookKernel:
 
         Returns: whether `ipykernel` is installed in environment.
         """
-        assert self.venv_path
-        executable = sys.executable
+        assert self.venv
+        assert self.executable
+        executable = self.executable
         cmd = [
             executable,
             "-c",


### PR DESCRIPTION
Added use of sys.executable to get full path to python as a follow up on issue https://github.com/natibek/erys/issues/7 .

This should solve using erys cross platform - as windows and linux has different paths to the python executable inside the .venv.